### PR TITLE
xcopy command attribute changed to just /e

### DIFF
--- a/lib_helper.h
+++ b/lib_helper.h
@@ -4,7 +4,7 @@
 
 #if defined(_WIN32) || defined(_WIN64) || defined(WIN32)
 	#define path_sep "\\"
-	#define copy_command "xcopy /s /e /t /y /i  "
+	#define copy_command "xcopy /e "
 #else
 	#define path_sep "/"
 	#define copy_command "cp -r "


### PR DESCRIPTION
previous command attributes with the combinations of /s /t /e etc doesn't workout. After testing on asma's computer it works with just the /e attribute.